### PR TITLE
feat: expand supported BLE services

### DIFF
--- a/src/lib/bluetooth.ts
+++ b/src/lib/bluetooth.ts
@@ -6,10 +6,53 @@ export const COMPATIBLE_MANUFACTURER_ID = 0xffff;
 export const COMPATIBLE_MANUFACTURER_DATA_PREFIX = new Uint8Array([0x42, 0x4c, 0x45]);
 
 // Known services used by the application.
+// Includes common GATT services so connected devices can expose a wide
+// variety of capabilities. Each entry is the 16-bit assigned number for the
+// service. Web Bluetooth accepts both strings and numbers for service UUIDs,
+// so using the numeric values keeps the list concise while still allowing
+// code elsewhere to reference them by name.
 export const KNOWN_SERVICE_UUIDS = [
-  'battery_service',
-  'health_thermometer',
-  'environmental_sensing',
+  0x1800, // Generic Access (GAP)
+  0x1801, // Generic Attribute (GATT)
+  0x1802, // Immediate Alert
+  0x1803, // Link Loss
+  0x1808, // Glucose
+  0x1809, // Health Thermometer
+  0x180a, // Device Information
+  0x180d, // Heart Rate
+  0x180f, // Battery Service
+  0x1814, // Running Speed and Cadence
+  0x1815, // Automation IO
+  0x1816, // Cycling Speed and Cadence
+  0x1818, // Cycling Power
+  0x181a, // Environmental Sensing
+  0x181b, // Body Composition
+  0x181c, // User Data
+  0x181d, // Weight Scale
+  0x181e, // Bond Management
+  0x181f, // Continuous Glucose Monitoring
+  0x1820, // Internet Protocol Support
+  0x1822, // Pulse Oximeter
+  0x1826, // Fitness Machine
+  0x1829, // Reconnection Configuration
+  0x183a, // Insulin Delivery
+  0x183b, // Binary Sensor
+  0x183c, // Emergency Configuration
+  0x183d, // Authorization Control
+  0x183e, // Physical Activity Monitor
+  0x183f, // Elapsed Time
+  0x1840, // Generic Health Sensor
+  0x1843, // Audio Input Control
+  0x1844, // Volume Control
+  0x184d, // Microphone Control
+  0x184e, // Audio Stream Control
+  0x184f, // Broadcast Audio Scan
+  0x1850, // Published Audio Capabilities
+  0x1851, // Basic Audio Announcement
+  0x1857, // Electronic Shelf Label
+  0x185a, // Industrial Measurement Device
+  0x185b, // Ranging
+  0x185c, // HID ISO
 ] as const;
 
 // Mapping of known characteristic UUIDs to their corresponding widget data types.


### PR DESCRIPTION
## Summary
- broaden KNOWN_SERVICE_UUIDS to cover many standard GATT services

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a72dc0d2ac8328a84328c18898fb81