### PR TITLE
feat: verify BLE device compatibility via manufacturer data

### DIFF
--- a/COMPATIBLE_DEVICES.txt
+++ b/COMPATIBLE_DEVICES.txt
@@ -10,12 +10,13 @@ To create a compatible ESP32 device:
 2. When advertising, include the manufacturer data:
    - Company Identifier: 0xFFFF (reserved for testing)
    - Data payload prefix: 0x42 0x4C 0x45 ('BLE')
-3. Expose the following services and characteristics:
-   - Battery Service (0x180F) with Battery Level characteristic (0x2A19)
-   - Health Thermometer (0x1809) with Temperature characteristic (0x2A6E)
-   - Environmental Sensing (0x181A) with Humidity characteristic (0x2A6F)
+3. Optionally expose any GATT services and characteristics you wish. The app
+   will attempt to read the Battery Level (0x180F/0x2A19), Temperature
+   (0x1809/0x2A6E) and Humidity (0x181A/0x2A6F) characteristics when available,
+   but their presence is not required for a device to be considered compatible.
 4. Update characteristic values as your sensors change.
 5. Ensure the device advertises while disconnected so it can be discovered.
 
 Devices following these guidelines will appear in the scan dialog and their
-characteristic values will populate widgets in the dashboard.
+characteristic values will populate widgets in the dashboard when those
+services are present.

--- a/src/lib/bluetooth.ts
+++ b/src/lib/bluetooth.ts
@@ -5,54 +5,24 @@ export const COMPATIBLE_MANUFACTURER_ID = 0xffff;
 // ASCII 'BLE' so custom firmware can advertise it in the manufacturer data payload.
 export const COMPATIBLE_MANUFACTURER_DATA_PREFIX = new Uint8Array([0x42, 0x4c, 0x45]);
 
-// Known services used by the application.
-// Includes common GATT services so connected devices can expose a wide
-// variety of capabilities. Each entry is the 16-bit assigned number for the
-// service. Web Bluetooth accepts both strings and numbers for service UUIDs,
-// so using the numeric values keeps the list concise while still allowing
-// code elsewhere to reference them by name.
+// Returns true if the provided manufacturer data begins with the expected prefix.
+export function isCompatibleManufacturerData(data?: DataView | null): boolean {
+  if (!data || data.byteLength < COMPATIBLE_MANUFACTURER_DATA_PREFIX.length) {
+    return false;
+  }
+  for (let i = 0; i < COMPATIBLE_MANUFACTURER_DATA_PREFIX.length; i++) {
+    if (data.getUint8(i) !== COMPATIBLE_MANUFACTURER_DATA_PREFIX[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Services the app attempts to access when available. These are not used to
+// judge device compatibility but enable reading of common characteristics.
 export const KNOWN_SERVICE_UUIDS = [
-  0x1800, // Generic Access (GAP)
-  0x1801, // Generic Attribute (GATT)
-  0x1802, // Immediate Alert
-  0x1803, // Link Loss
-  0x1808, // Glucose
-  0x1809, // Health Thermometer
-  0x180a, // Device Information
-  0x180d, // Heart Rate
   0x180f, // Battery Service
-  0x1814, // Running Speed and Cadence
-  0x1815, // Automation IO
-  0x1816, // Cycling Speed and Cadence
-  0x1818, // Cycling Power
-  0x181a, // Environmental Sensing
-  0x181b, // Body Composition
-  0x181c, // User Data
-  0x181d, // Weight Scale
-  0x181e, // Bond Management
-  0x181f, // Continuous Glucose Monitoring
-  0x1820, // Internet Protocol Support
-  0x1822, // Pulse Oximeter
-  0x1826, // Fitness Machine
-  0x1829, // Reconnection Configuration
-  0x183a, // Insulin Delivery
-  0x183b, // Binary Sensor
-  0x183c, // Emergency Configuration
-  0x183d, // Authorization Control
-  0x183e, // Physical Activity Monitor
-  0x183f, // Elapsed Time
-  0x1840, // Generic Health Sensor
-  0x1843, // Audio Input Control
-  0x1844, // Volume Control
-  0x184d, // Microphone Control
-  0x184e, // Audio Stream Control
-  0x184f, // Broadcast Audio Scan
-  0x1850, // Published Audio Capabilities
-  0x1851, // Basic Audio Announcement
-  0x1857, // Electronic Shelf Label
-  0x185a, // Industrial Measurement Device
-  0x185b, // Ranging
-  0x185c, // HID ISO
+  0x181a, // Environmental Sensing (Temperature & Humidity)
 ] as const;
 
 // Mapping of known characteristic UUIDs to their corresponding widget data types.


### PR DESCRIPTION
## Summary
- ensure only devices with expected manufacturer data are accepted
- streamline service discovery to avoid judging compatibility by services
- document optional GATT services for compatible ESP32 devices

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76803b4148328a2b16d9f206ec56b