### PR TITLE
feat: verify BLE device compatibility via manufacturer data

### DIFF
--- a/COMPATIBLE_DEVICES.txt
+++ b/COMPATIBLE_DEVICES.txt
@@ -10,12 +10,13 @@ To create a compatible ESP32 device:
 2. When advertising, include the manufacturer data:
    - Company Identifier: 0xFFFF (reserved for testing)
    - Data payload prefix: 0x42 0x4C 0x45 ('BLE')
-3. Expose the following services and characteristics:
-   - Battery Service (0x180F) with Battery Level characteristic (0x2A19)
-   - Health Thermometer (0x1809) with Temperature characteristic (0x2A6E)
-   - Environmental Sensing (0x181A) with Humidity characteristic (0x2A6F)
+3. Optionally expose any GATT services and characteristics you wish. When
+   present, the app routes available services to widgets and displays their
+   data using appropriate units, but none are required for a device to be
+   considered compatible.
 4. Update characteristic values as your sensors change.
 5. Ensure the device advertises while disconnected so it can be discovered.
 
 Devices following these guidelines will appear in the scan dialog and their
-characteristic values will populate widgets in the dashboard.
+characteristic values will populate widgets in the dashboard when those
+services are present.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ export default function Home() {
       connectDevice,
       disconnectDevice,
       renameDevice,
+      readCharacteristicValue,
     } = useBluetooth();
 
   const [widgets, setWidgets] = React.useState<Widget[]>([]);
@@ -37,63 +38,18 @@ export default function Home() {
   const readValues = React.useCallback(
     async (targets: Device[] = connectedDevices) => {
       const devicePromises = targets.map(async device => {
-
-        const server = device.device.gatt;
-        if (!server) return;
-        if (!server.connected) {
-          try {
-            await server.connect();
-          } catch (err) {
-            console.error(`Failed to connect to ${device.name}:`, err);
-            return;
-          }
-        }
+        const types = Object.keys(device.characteristics ?? {}) as WidgetDataType[];
+        if (!types.length) return;
 
         const values: Record<string, number> = {};
-
-        const characteristicPromises: Promise<void>[] = [];
-
-        characteristicPromises.push(
-          (async () => {
-            try {
-              const service = await server.getPrimaryService("battery_service");
-              const characteristic = await service.getCharacteristic("battery_level");
-              const value = await characteristic.readValue();
-              values.battery = value.getUint8(0);
-            } catch (err) {
-              console.error(`Battery read failed for ${device.name}`, err);
+        await Promise.all(
+          types.map(async type => {
+            const val = await readCharacteristicValue(device.id, type);
+            if (val !== null) {
+              values[type] = val;
             }
-          })()
+          })
         );
-
-        characteristicPromises.push(
-          (async () => {
-            try {
-              const service = await server.getPrimaryService("health_thermometer");
-              const characteristic = await service.getCharacteristic("temperature_measurement");
-              const value = await characteristic.readValue();
-              const temp = value.getFloat32(0, true);
-              values.temperature = Math.round(temp * 10) / 10;
-            } catch (err) {
-              console.error(`Temperature read failed for ${device.name}`, err);
-            }
-          })()
-        );
-
-        characteristicPromises.push(
-          (async () => {
-            try {
-              const service = await server.getPrimaryService("environmental_sensing");
-              const characteristic = await service.getCharacteristic("humidity");
-              const value = await characteristic.readValue();
-              values.humidity = value.getUint8(0);
-            } catch (err) {
-              console.error(`Humidity read failed for ${device.name}`, err);
-            }
-          })()
-        );
-
-        await Promise.all(characteristicPromises);
 
         if (Object.keys(values).length) {
           setData(prev => ({
@@ -101,14 +57,11 @@ export default function Home() {
             [device.id]: { ...(prev[device.id] ?? {}), ...values },
           }));
         }
-
       });
 
       await Promise.all(devicePromises);
     },
-
-    [connectedDevices]
-
+    [connectedDevices, readCharacteristicValue]
   );
 
   React.useEffect(() => {

--- a/src/components/add-widget-sheet.tsx
+++ b/src/components/add-widget-sheet.tsx
@@ -48,6 +48,10 @@ export function AddWidgetSheet({ children, open, onOpenChange, onAddWidget, conn
     },
   });
 
+  const deviceId = form.watch("deviceId");
+  const selectedDevice = connectedDevices.find(d => d.id === deviceId);
+  const availableDataTypes = Object.keys(selectedDevice?.characteristics ?? {}) as WidgetDataType[];
+
   function onSubmit(data: WidgetFormValues) {
     onAddWidget(data as Omit<Widget, 'id'>);
     form.reset();
@@ -121,7 +125,7 @@ export function AddWidgetSheet({ children, open, onOpenChange, onAddWidget, conn
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {widgetDataTypes.map(type => (
+                      {availableDataTypes.map(type => (
                         <SelectItem key={type} value={type}>
                           {type.charAt(0).toUpperCase() + type.slice(1)}
                         </SelectItem>

--- a/src/components/widget.tsx
+++ b/src/components/widget.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { MoreVertical, Trash2, Thermometer, Droplets, Battery } from "lucide-react";
+import { MoreVertical, Trash2, Thermometer, Droplets, Battery, Heart } from "lucide-react";
 import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from "recharts";
 import type { Widget as WidgetType } from "@/lib/types";
 
@@ -21,6 +21,7 @@ const dataTypeIcons: Partial<Record<WidgetType['dataType'], JSX.Element>> = {
   temperature: <Thermometer className="w-4 h-4 text-muted-foreground" />,
   humidity: <Droplets className="w-4 h-4 text-muted-foreground" />,
   battery: <Battery className="w-4 h-4 text-muted-foreground" />,
+  heart_rate: <Heart className="w-4 h-4 text-muted-foreground" />,
 };
 
 const getUnit = (dataType: WidgetType['dataType']) => {
@@ -28,13 +29,15 @@ const getUnit = (dataType: WidgetType['dataType']) => {
     case 'temperature': return '°C';
     case 'humidity': return '%';
     case 'battery': return '%';
+    case 'heart_rate': return 'bpm';
     default: return '';
   }
 };
 
 export function Widget({ widget, data, deviceName, onRemove }: WidgetProps) {
   const unit = getUnit(widget.dataType);
-  const displayValue = data !== undefined ? data.toFixed(1) : '--';
+  const decimals = widget.dataType === 'temperature' ? 1 : 0;
+  const displayValue = data !== undefined ? data.toFixed(decimals) : '--';
   const progressValue = data !== undefined ? data : 0;
   const [history, setHistory] = useState<{ time: number; value: number }[]>([]);
 

--- a/src/lib/bluetooth.ts
+++ b/src/lib/bluetooth.ts
@@ -5,54 +5,26 @@ export const COMPATIBLE_MANUFACTURER_ID = 0xffff;
 // ASCII 'BLE' so custom firmware can advertise it in the manufacturer data payload.
 export const COMPATIBLE_MANUFACTURER_DATA_PREFIX = new Uint8Array([0x42, 0x4c, 0x45]);
 
-// Known services used by the application.
-// Includes common GATT services so connected devices can expose a wide
-// variety of capabilities. Each entry is the 16-bit assigned number for the
-// service. Web Bluetooth accepts both strings and numbers for service UUIDs,
-// so using the numeric values keeps the list concise while still allowing
-// code elsewhere to reference them by name.
+// Returns true if the provided manufacturer data begins with the expected prefix.
+export function isCompatibleManufacturerData(data?: DataView | null): boolean {
+  if (!data || data.byteLength < COMPATIBLE_MANUFACTURER_DATA_PREFIX.length) {
+    return false;
+  }
+  for (let i = 0; i < COMPATIBLE_MANUFACTURER_DATA_PREFIX.length; i++) {
+    if (data.getUint8(i) !== COMPATIBLE_MANUFACTURER_DATA_PREFIX[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Services the app attempts to access when available. These are not used to
+// judge device compatibility but enable reading of common characteristics.
 export const KNOWN_SERVICE_UUIDS = [
-  0x1800, // Generic Access (GAP)
-  0x1801, // Generic Attribute (GATT)
-  0x1802, // Immediate Alert
-  0x1803, // Link Loss
-  0x1808, // Glucose
-  0x1809, // Health Thermometer
-  0x180a, // Device Information
-  0x180d, // Heart Rate
   0x180f, // Battery Service
-  0x1814, // Running Speed and Cadence
-  0x1815, // Automation IO
-  0x1816, // Cycling Speed and Cadence
-  0x1818, // Cycling Power
-  0x181a, // Environmental Sensing
-  0x181b, // Body Composition
-  0x181c, // User Data
-  0x181d, // Weight Scale
-  0x181e, // Bond Management
-  0x181f, // Continuous Glucose Monitoring
-  0x1820, // Internet Protocol Support
-  0x1822, // Pulse Oximeter
-  0x1826, // Fitness Machine
-  0x1829, // Reconnection Configuration
-  0x183a, // Insulin Delivery
-  0x183b, // Binary Sensor
-  0x183c, // Emergency Configuration
-  0x183d, // Authorization Control
-  0x183e, // Physical Activity Monitor
-  0x183f, // Elapsed Time
-  0x1840, // Generic Health Sensor
-  0x1843, // Audio Input Control
-  0x1844, // Volume Control
-  0x184d, // Microphone Control
-  0x184e, // Audio Stream Control
-  0x184f, // Broadcast Audio Scan
-  0x1850, // Published Audio Capabilities
-  0x1851, // Basic Audio Announcement
-  0x1857, // Electronic Shelf Label
-  0x185a, // Industrial Measurement Device
-  0x185b, // Ranging
-  0x185c, // HID ISO
+  0x181a, // Environmental Sensing (Temperature & Humidity)
+  0x180d, // Heart Rate Service
+  0x1809, // Health Thermometer Service
 ] as const;
 
 // Mapping of known characteristic UUIDs to their corresponding widget data types.
@@ -60,6 +32,7 @@ export const characteristicUUIDToDataType: Record<string, WidgetDataType> = {
   "00002a6e-0000-1000-8000-00805f9b34fb": "temperature", // Temperature (Environmental Sensing)
   "00002a6f-0000-1000-8000-00805f9b34fb": "humidity",    // Humidity (Environmental Sensing)
   "00002a19-0000-1000-8000-00805f9b34fb": "battery",     // Battery Level
+  "00002a37-0000-1000-8000-00805f9b34fb": "heart_rate",  // Heart Rate Measurement
 };
 
 // Reverse mapping to get characteristic UUID from a data type.
@@ -81,6 +54,11 @@ export function parseCharacteristicValue(type: WidgetDataType, view: DataView): 
     case "battery":
       // Unsigned 8-bit percentage.
       return view.getUint8(0);
+    case "heart_rate":
+      // Flags in first byte: bit0 indicates value format.
+      return (view.getUint8(0) & 0x01)
+        ? view.getUint16(1, /*littleEndian=*/true)
+        : view.getUint8(1);
     default:
       return NaN;
   }


### PR DESCRIPTION
## Summary
- document that exposed GATT services populate widgets with appropriate units
- detect characteristics per device and read values generically
- add heart-rate service support with units and icons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76803b4148328a2b16d9f206ec56b