### PR TITLE
Show BLE device characteristics dynamically

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,6 @@ import { Button } from "@/components/ui/button";
 import { Plus, Router } from "lucide-react";
 import { AddWidgetSheet } from "@/components/add-widget-sheet";
 import { useBluetooth } from "@/hooks/use-bluetooth";
-import type { WidgetDataType } from "@/lib/types";
 
 export default function Home() {
     const {
@@ -42,7 +41,7 @@ export default function Home() {
           const values: Record<string, number> = {};
 
           const characteristicPromises = deviceWidgets.map(async widget => {
-            const value = await readCharacteristicValue(device.id, widget.dataType as WidgetDataType);
+            const value = await readCharacteristicValue(device.id, widget.dataType);
             if (value !== null) {
               values[widget.dataType] = value;
             }

--- a/src/components/widget.tsx
+++ b/src/components/widget.tsx
@@ -9,6 +9,7 @@ import { Progress } from "@/components/ui/progress";
 import { MoreVertical, Trash2 } from "lucide-react";
 import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from "recharts";
 import type { Widget as WidgetType } from "@/lib/types";
+import { getCharacteristicName, getCharacteristicUnit } from "@/lib/bluetooth";
 
 interface WidgetProps {
   widget: WidgetType;
@@ -17,17 +18,8 @@ interface WidgetProps {
   onRemove: (widgetId: string) => void;
 }
 
-const getUnit = (dataType: WidgetType['dataType']) => {
-  switch (dataType) {
-    case 'temperature': return '°C';
-    case 'humidity': return '%';
-    case 'battery': return '%';
-    default: return '';
-  }
-};
-
 export function Widget({ widget, data, deviceName, onRemove }: WidgetProps) {
-  const unit = getUnit(widget.dataType);
+  const unit = getCharacteristicUnit(widget.dataType);
   const displayValue = data !== undefined ? data.toFixed(1) : '--';
   const progressValue = data !== undefined ? data : 0;
   const [history, setHistory] = useState<{ time: number; value: number }[]>([]);
@@ -40,7 +32,8 @@ export function Widget({ widget, data, deviceName, onRemove }: WidgetProps) {
     });
   }, [data]);
   
-  const formattedDataType = widget.dataType.charAt(0).toUpperCase() + widget.dataType.slice(1);
+  const displayName = getCharacteristicName(widget.dataType);
+  const formattedDataType = displayName.charAt(0).toUpperCase() + displayName.slice(1);
 
   return (
     <Card className="flex flex-col">

--- a/src/hooks/use-bluetooth.ts
+++ b/src/hooks/use-bluetooth.ts
@@ -5,7 +5,6 @@ import { useState, useCallback } from 'react';
 import type { Device, WidgetDataType } from '@/lib/types';
 import { useToast } from "@/hooks/use-toast";
 import {
-  characteristicUUIDToDataType,
   parseCharacteristicValue,
   COMPATIBLE_MANUFACTURER_ID,
   COMPATIBLE_MANUFACTURER_DATA_PREFIX,
@@ -118,7 +117,7 @@ export function useBluetooth() {
       console.log(`Connecting to ${deviceWrapper.name}...`);
       const server = await deviceWrapper.device.gatt?.connect();
 
-      const characteristics: Partial<Record<WidgetDataType, BluetoothRemoteGATTCharacteristic>> = {};
+      const characteristics: Record<string, BluetoothRemoteGATTCharacteristic> = {};
       if (server) {
         try {
           const services = await server.getPrimaryServices();
@@ -126,10 +125,7 @@ export function useBluetooth() {
             try {
               const chars = await service.getCharacteristics();
               for (const char of chars) {
-                const dataType = characteristicUUIDToDataType[char.uuid];
-                if (dataType) {
-                  characteristics[dataType] = char;
-                }
+                characteristics[char.uuid] = char;
               }
             } catch (_) {
               // Ignore missing characteristics

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,51 +1,5 @@
 
-export const widgetDataTypes = [
-  "temperature",
-  "humidity",
-  "battery",
-  "generic_access",
-  "generic_attribute",
-  "immediate_alert",
-  "link_loss",
-  "glucose",
-  "health_thermometer",
-  "device_information",
-  "heart_rate",
-  "battery_service",
-  "running_speed_and_cadence",
-  "automation_io",
-  "cycling_speed_and_cadence",
-  "cycling_power",
-  "environmental_sensing",
-  "body_composition",
-  "user_data",
-  "weight_scale",
-  "bond_management",
-  "continuous_glucose_monitoring",
-  "internet_protocol_support",
-  "pulse_oximeter",
-  "fitness_machine",
-  "reconnection_configuration",
-  "insulin_delivery",
-  "binary_sensor",
-  "emergency_configuration",
-  "authorization_control",
-  "physical_activity_monitor",
-  "elapsed_time",
-  "generic_health_sensor",
-  "audio_input_control",
-  "volume_control",
-  "microphone_control",
-  "audio_stream_control",
-  "broadcast_audio_scan",
-  "published_audio_capabilities",
-  "basic_audio_announcement",
-  "electronic_shelf_label",
-  "industrial_measurement_device",
-  "ranging",
-  "hid_iso",
-] as const;
-export type WidgetDataType = (typeof widgetDataTypes)[number];
+export type WidgetDataType = string;
 
 export type Device = {
   id: string;
@@ -55,10 +9,10 @@ export type Device = {
   customName?: string;
   device: BluetoothDevice;
   /**
-   * Map of supported characteristic UUIDs keyed by their associated widget data type.
+   * Map of supported characteristic UUIDs keyed by their UUID.
    * Populated when a device is connected and its services are discovered.
    */
-  characteristics?: Partial<Record<WidgetDataType, BluetoothRemoteGATTCharacteristic>>;
+  characteristics?: Record<string, BluetoothRemoteGATTCharacteristic>;
 };
 
 export type WidgetType = 'value' | 'gauge' | 'graph';


### PR DESCRIPTION
## Summary
- display available BLE characteristics for each device instead of fixed list
- include metadata and parsers for known characteristics
- preserve compatibility screening via manufacturer data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad5e3d567c8328b4b8ec51deb34c4d