### PR TITLE
feat: add widget configuration settings

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,4 +28,9 @@ export type Widget = {
   deviceId: string;
   dataType: WidgetDataType;
   type: WidgetType;
+  settings: {
+    historyLength: number;
+    lineColor: string;
+    refreshRate: number;
+  };
 };


### PR DESCRIPTION
## Summary
- extend Widget type to include adjustable settings
- allow users to configure history length, line color, and refresh rate when adding a widget
- use widget settings for throttled updates, history length, and graph line color

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae087227e08328b2411000427b9a9d