### PR TITLE
Enable scrolling in Add Widget sheet

### DIFF
--- a/src/components/add-widget-sheet.tsx
+++ b/src/components/add-widget-sheet.tsx
@@ -78,7 +78,7 @@ export function AddWidgetSheet({ children, open, onOpenChange, onAddWidget, conn
           {children}
         </SheetTrigger>
       )}
-      <SheetContent>
+      <SheetContent className="overflow-y-auto">
         <SheetHeader>
           <SheetTitle>Add a new widget</SheetTitle>
           <SheetDescription>


### PR DESCRIPTION
## Summary
- allow Add Widget sheet to scroll so all options are reachable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aea815f35c8328b490afa461534fa8