### PR TITLE
Persist dashboard widgets in local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ belIOT is a Web Bluetooth dashboard for discovering, connecting, and visualizing
 - **Device scanning & management** – use the Device Manager to scan for BLE devices, connect or disconnect them, and rename devices for easy identification.
 - **Customizable widgets** – add widgets that read GATT characteristic values and display live data from connected devices on the dashboard.
 - **Real-time updates** – device data is polled periodically so widgets stay current as values change.
+- **Persistent widgets** – layouts and widget settings are saved in the browser so your dashboard returns after a refresh.
 
 ## Getting Started
 1. **Install dependencies**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Plus, Router } from "lucide-react";
 import { AddWidgetSheet } from "@/components/add-widget-sheet";
 import { useBluetooth } from "@/hooks/use-bluetooth";
+import { loadFromStorage, saveToStorage } from "@/lib/utils";
 
 export default function Home() {
     const {
@@ -33,6 +34,14 @@ export default function Home() {
   const [isAddWidgetSheetOpen, setIsAddWidgetSheetOpen] = React.useState(false);
 
   const connectedDevices = React.useMemo(() => devices.filter(d => d.connected), [devices]);
+
+  React.useEffect(() => {
+    setWidgets(loadFromStorage<Widget[]>("widgets", []));
+  }, []);
+
+  React.useEffect(() => {
+    saveToStorage("widgets", widgets);
+  }, [widgets]);
 
     const readValues = React.useCallback(
       async (targets: Device[] = connectedDevices) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function loadFromStorage<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback
+  try {
+    const raw = window.localStorage.getItem(key)
+    return raw ? (JSON.parse(raw) as T) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function saveToStorage<T>(key: string, value: T) {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // ignore write errors
+  }
+}


### PR DESCRIPTION
## Summary
- save and load widgets using new localStorage helpers
- add safe `loadFromStorage` and `saveToStorage` utilities
- document persistent widgets in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aeb1eb6af88328a86102011c7d368b