### PR TITLE
feat: persist connected devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ belIOT is a Web Bluetooth dashboard for discovering, connecting, and visualizing
 - **Customizable widgets** – add widgets that read GATT characteristic values and display live data from connected devices on the dashboard.
 - **Real-time updates** – device data is polled periodically so widgets stay current as values change.
 - **Persistent widgets** – layouts and widget settings are saved in the browser so your dashboard returns after a refresh.
+- **Saved devices** – connected devices are remembered in the browser and restored on load for easy reconnection.
 - **Reading logs** – each widget keeps a buffer of readings that can be exported as CSV or cleared at any time.
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- restore previously allowed Bluetooth devices on load
- persist device ids and custom names in local storage
- document device persistence in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aecedb79d08328b736688de63b7562