### PR TITLE
feat: remember and auto reconnect devices

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ export default function Home() {
       disconnectDevice,
       renameDevice,
       readCharacteristicValue,
+      toggleAutoConnect,
     } = useBluetooth();
 
   const [widgets, setWidgets] = React.useState<Widget[]>([]);
@@ -101,6 +102,10 @@ export default function Home() {
     renameDevice(deviceId, newName);
   };
 
+  const handleAutoConnectChange = (deviceId: string, value: boolean) => {
+    toggleAutoConnect(deviceId, value);
+  };
+
   const handleAddWidget = (widget: Omit<Widget, 'id'>) => {
     setWidgets(prevWidgets => [...prevWidgets, { ...widget, id: `widget-${Date.now()}` }]);
     setIsAddWidgetSheetOpen(false);
@@ -141,6 +146,7 @@ export default function Home() {
               devices={devices}
               onConnectToggle={handleConnectToggle}
               onRenameDevice={handleRenameDevice}
+              onAutoConnectChange={handleAutoConnectChange}
               onScan={requestDevice}
           />
         </DialogContent>

--- a/src/components/device-manager.tsx
+++ b/src/components/device-manager.tsx
@@ -7,16 +7,18 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
 import { Bluetooth, BluetoothConnected, Edit, Check, X, Signal, Rss } from "lucide-react";
 
 interface DeviceManagerProps {
   devices: Device[];
   onConnectToggle: (deviceId: string) => void;
   onRenameDevice: (deviceId: string, newName: string) => void;
+  onAutoConnectChange: (deviceId: string, value: boolean) => void;
   onScan: () => void;
 }
 
-export function DeviceManager({ devices, onConnectToggle, onRenameDevice, onScan }: DeviceManagerProps) {
+export function DeviceManager({ devices, onConnectToggle, onRenameDevice, onAutoConnectChange, onScan }: DeviceManagerProps) {
   const [editingDeviceId, setEditingDeviceId] = React.useState<string | null>(null);
   const [tempName, setTempName] = React.useState("");
 
@@ -93,6 +95,11 @@ export function DeviceManager({ devices, onConnectToggle, onRenameDevice, onScan
                                         {getRssiIcon(device.rssi)}
                                         {device.rssi}
                                     </Badge>
+                                    <Switch
+                                      checked={device.autoConnect ?? false}
+                                      onCheckedChange={checked => onAutoConnectChange(device.id, checked)}
+                                      aria-label="Auto connect"
+                                    />
                                     {device.connected && (
                                         <Button size="icon" variant="ghost" className="w-7 h-7" onClick={() => handleEditStart(device)}><Edit className="w-4 h-4" /></Button>
                                     )}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,10 @@ export type Device = {
   rssi: number;
   connected: boolean;
   customName?: string;
-  device: BluetoothDevice;
+  /** Whether to attempt reconnection automatically on load */
+  autoConnect?: boolean;
+  /** Underlying Bluetooth device instance, when available */
+  device?: BluetoothDevice;
   /**
    * Map of supported characteristic UUIDs keyed by their UUID.
    * Populated when a device is connected and its services are discovered.


### PR DESCRIPTION
## Summary
- persist previously connected devices and track auto-connect preference
- add UI switch to mark devices for automatic reconnection
- reconnect to saved devices on load when auto-connect is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b6b71a86a88328b5bd158e209903f6